### PR TITLE
Support for enum types in postgres. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Created by https://www.gitignore.io
+
+### Haskell ###
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.virtualenv
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+*.prof
+*.aux
+*.hp
+

--- a/library/PostgreSQLBinary/Types.hs
+++ b/library/PostgreSQLBinary/Types.hs
@@ -1,0 +1,18 @@
+module PostgreSQLBinary.Types 
+(
+  PGEnum(..)
+)
+where
+
+-- base-prelude
+-------------------------
+import BasePrelude
+
+-- text
+-------------------------
+import qualified Data.Text
+
+newtype PGEnum = PGEnum {getEnumText :: Data.Text.Text}
+                 deriving (Eq, Show)
+
+  

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -64,6 +64,7 @@ library
     PostgreSQLBinary.Array
     PostgreSQLBinary.Encoder
     PostgreSQLBinary.Decoder
+    PostgreSQLBinary.Types
   build-depends:
     -- parsers:
     attoparsec >= 0.10 && < 0.13,


### PR DESCRIPTION
Added a type `PGEnum` which is a `newtype` wrapper over `Data.Text.Text` as discussed [here](https://github.com/nikita-volkov/hasql/issues/16). 
