### PR TITLE
Composite types

### DIFF
--- a/executables/Tests.hs
+++ b/executables/Tests.hs
@@ -5,6 +5,7 @@ import BasePrelude hiding (assert)
 import Test.Framework
 import Test.QuickCheck.Instances
 import Data.Time
+import qualified Data.Vector as V
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
@@ -19,6 +20,7 @@ import qualified PostgreSQLBinary.PTI as PTI
 import qualified PostgreSQLBinary.Encoder as Encoder
 import qualified PostgreSQLBinary.Decoder as Decoder
 import qualified PostgreSQLBinary.Array as Array
+import qualified PostgreSQLBinary.Composite as Composite
 
 
 type Text = T.Text
@@ -178,21 +180,34 @@ arrayGen =
   where
     dimGen =
       (,) <$> choose (1, 7) <*> pure 1
-    valueGen =
-      do
-        (pti, gen) <- elements [(PTI.int8, mkGen (Encoder.int8 . Left)),
-                                (PTI.bool, mkGen Encoder.bool),
-                                (PTI.date, mkGen Encoder.date),
-                                (PTI.text, mkGen Encoder.text),
-                                (PTI.bytea, mkGen Encoder.bytea)]
-        return (gen, PTI.oidOf pti, fromJust $ PTI.arrayOIDOf pti)
-      where
-        mkGen renderer =
-          fmap (fmap renderer) arbitrary
+
+
     dimsToNValues =
       product . map dimensionWidth
       where
         dimensionWidth (x, _) = fromIntegral x
+
+valueGen :: Gen (Gen (Maybe BC.ByteString), Word32, Word32)
+valueGen =
+  do
+    (pti, gen) <- elements [(PTI.int8, mkGen (Encoder.int8 . Left)),
+                            (PTI.bool, mkGen Encoder.bool),
+                            (PTI.date, mkGen Encoder.date),
+                            (PTI.text, mkGen Encoder.text),
+                            (PTI.bytea, mkGen Encoder.bytea)]
+    return (gen, PTI.oidOf pti, fromJust $ PTI.arrayOIDOf pti)
+  where
+    mkGen renderer =
+      fmap (fmap renderer) arbitrary
+
+compositesGen :: Gen (V.Vector Composite.Field)
+compositesGen = do
+  -- hacky way of reducing the size of these vectors :)
+  Positive lenW <- arbitrary :: Gen (Positive Word16)
+  V.replicateM (fromIntegral lenW) $ do
+    (getVal, oid, _) <- valueGen
+    val              <- getVal
+    return (Composite.createField oid val)
 
 -- * Constants
 -------------------------
@@ -601,3 +616,6 @@ prop_arrayData =
              (nonNullRenderer Encoder.array)
              (nonNullParser Decoder.array)
 
+prop_compositeId =
+  forAll compositesGen $ \fields ->
+    Right fields === Decoder.composite (Encoder.composite fields)

--- a/executables/Tests.hs
+++ b/executables/Tests.hs
@@ -203,7 +203,7 @@ valueGen =
 compositesGen :: Gen (V.Vector Composite.Field)
 compositesGen = do
   -- hacky way of reducing the size of these vectors :)
-  Positive lenW <- arbitrary :: Gen (Positive Word16)
+  Positive lenW <- arbitrary :: Gen (Positive Word8)
   V.replicateM (fromIntegral lenW) $ do
     (getVal, oid, _) <- valueGen
     val              <- getVal

--- a/executables/Tests.hs
+++ b/executables/Tests.hs
@@ -203,7 +203,7 @@ valueGen =
 compositesGen :: Gen (V.Vector Composite.Field)
 compositesGen = do
   -- hacky way of reducing the size of these vectors :)
-  Positive lenW <- arbitrary :: Gen (Positive Word8)
+  lenW <- arbitrary :: Gen Word8
   V.replicateM (fromIntegral lenW) $ do
     (getVal, oid, _) <- valueGen
     val              <- getVal

--- a/library/PostgreSQLBinary/Composite.hs
+++ b/library/PostgreSQLBinary/Composite.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PostgreSQLBinary.Composite
+  ( Field(..)
+  , parseField
+  ) where
+import PostgreSQLBinary.Prelude
+
+data Field
+  = Field
+    { fieldOid  :: {-# UNPACK #-} !Int32
+    , fieldSize :: {-# UNPACK #-} !Int32
+    , field     :: !ByteString }
+  | NULL
+ deriving (Show, Eq, Ord)
+
+{-# INLINE parseField #-}
+parseField :: (Int32 -> ByteString -> Either Text a) -> Field -> Either Text a
+parseField parse f =
+  case f of
+    Field oid _ bs -> parse oid bs
+    NULL           -> Left "parseField: NULL"

--- a/library/PostgreSQLBinary/Composite.hs
+++ b/library/PostgreSQLBinary/Composite.hs
@@ -2,19 +2,30 @@
 module PostgreSQLBinary.Composite
   ( Field(..)
   , parseField
+  , createField
   ) where
+
+import qualified Data.ByteString as B
+
 import PostgreSQLBinary.Prelude
 
 data Field
-  = Field { fieldOid  :: {-# UNPACK #-} !Int32
+  = Field { fieldOid  :: {-# UNPACK #-} !Word32
+            -- | For convenience this is Int32. Note that PG only supports
+            -- <http://doxygen.postgresql.org/datum_8c.html Datum> up to 1GiB.
           , fieldSize :: {-# UNPACK #-} !Int32
           , field     :: !ByteString }
-  | NULL { fieldOid :: {-# UNPACK #-} !Int32 }
+  | NULL { fieldOid :: {-# UNPACK #-} !Word32 }
  deriving (Show, Eq, Ord)
 
 {-# INLINE parseField #-}
-parseField :: (Int32 -> ByteString -> Either Text a) -> Field -> Either Text a
+parseField :: (Word32 -> ByteString -> Either Text a) -> Field -> Either Text a
 parseField parse f =
   case f of
     Field oid _ bs -> parse oid bs
     NULL _oid      -> Left "parseField: NULL"
+
+createField :: Word32 -> Maybe ByteString -> Field
+createField oid mbs = case mbs of
+  Just f  -> Field oid (fromIntegral (B.length f)) f
+  Nothing -> NULL oid

--- a/library/PostgreSQLBinary/Composite.hs
+++ b/library/PostgreSQLBinary/Composite.hs
@@ -6,11 +6,10 @@ module PostgreSQLBinary.Composite
 import PostgreSQLBinary.Prelude
 
 data Field
-  = Field
-    { fieldOid  :: {-# UNPACK #-} !Int32
-    , fieldSize :: {-# UNPACK #-} !Int32
-    , field     :: !ByteString }
-  | NULL
+  = Field { fieldOid  :: {-# UNPACK #-} !Int32
+          , fieldSize :: {-# UNPACK #-} !Int32
+          , field     :: !ByteString }
+  | NULL { fieldOid :: {-# UNPACK #-} !Int32 }
  deriving (Show, Eq, Ord)
 
 {-# INLINE parseField #-}
@@ -18,4 +17,4 @@ parseField :: (Int32 -> ByteString -> Either Text a) -> Field -> Either Text a
 parseField parse f =
   case f of
     Field oid _ bs -> parse oid bs
-    NULL           -> Left "parseField: NULL"
+    NULL _oid      -> Left "parseField: NULL"

--- a/library/PostgreSQLBinary/Decoder.hs
+++ b/library/PostgreSQLBinary/Decoder.hs
@@ -195,14 +195,16 @@ size s = case B.take 4 s of
      | otherwise        -> Left "No length."
 
 data Field a
+data Field
   = Field
     { fieldOid   :: {-# UNPACK #-} !Int32
     , fieldSize  :: {-# UNPACK #-} !Int32
-    , field      :: !a } 
-  | NULL
+    , field      :: !ByteString } 
+  | NULL 
  deriving (Show, Eq, Ord)
 
-compositeFields :: D (V.Vector (Field ByteString))
+-- | Parse the fields of a composite type
+compositeFields :: D (V.Vector Field)
 compositeFields row = do
   s <- size row
 

--- a/library/PostgreSQLBinary/Decoder.hs
+++ b/library/PostgreSQLBinary/Decoder.hs
@@ -206,8 +206,8 @@ slice bs n len =
   else Left "slice: string too short"
 
 -- | Parse the fields of a composite type
-compositeFields :: D (V.Vector Composite.Field)
-compositeFields row = do
+composite :: D (V.Vector Composite.Field)
+composite row = do
   (size, fields) <- takeInt32 row
   let
     int32At :: Int -> Either Text Int32
@@ -234,7 +234,8 @@ compositeFields row = do
               (,) (pos+8+max 0 leni) <$>
                 if len /= -1
                 then Composite.Field oid len <$> slice fields (pos+8) leni
-                else Right Composite.NULL
+                else Right (Composite.NULL oid)
+
           in case field of
             Left err        -> return (Just err)
             Right (pos', f) -> do

--- a/library/PostgreSQLBinary/Encoder.hs
+++ b/library/PostgreSQLBinary/Encoder.hs
@@ -182,9 +182,9 @@ composite vect = Builder.run (sizeTag <> foldMap field vect)
  where
   field :: Composite.Field -> BB.Builder
   field f = case f of
-    Composite.NULL  oid         -> BB.int32BE oid <> BB.int32BE (-1)
-    Composite.Field oid size bs -> BB.int32BE oid <> BB.int32BE size <>
+    Composite.NULL  oid         -> BB.word32BE oid <> BB.int32BE (-1)
+    Composite.Field oid size bs -> BB.word32BE oid <> BB.int32BE size <>
                                    BB.byteString bs
   sizeTag :: BB.Builder
-  sizeTag = BB.int32BE (fromIntegral (V.length vect) :: Int32)
+  sizeTag = BB.word32BE (fromIntegral (V.length vect) :: Word32)
     

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -72,6 +72,7 @@ library
     time >= 1.4 && < 1.6,
     scientific >= 0.2 && < 0.4,
     text >= 1 && < 1.3,
+    vector == 0.10.*,
     bytestring >= 0.10 && < 0.11,
     -- errors:
     loch-th == 0.2.*,

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -1,7 +1,7 @@
 name:
   postgresql-binary
 version:
-  0.5.3
+  0.6.0
 synopsis:
   Encoders and decoders for the PostgreSQL's binary format
 description:

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -60,6 +60,7 @@ library
     PostgreSQLBinary.Numeric
     PostgreSQLBinary.Time
     PostgreSQLBinary.Interval
+    PostgreSQLBinary.Composite
   exposed-modules:
     PostgreSQLBinary.Array
     PostgreSQLBinary.Encoder

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -60,9 +60,9 @@ library
     PostgreSQLBinary.Numeric
     PostgreSQLBinary.Time
     PostgreSQLBinary.Interval
-    PostgreSQLBinary.Composite
   exposed-modules:
     PostgreSQLBinary.Array
+    PostgreSQLBinary.Composite
     PostgreSQLBinary.Encoder
     PostgreSQLBinary.Decoder
   build-depends:
@@ -73,8 +73,8 @@ library
     time >= 1.4 && < 1.6,
     scientific >= 0.2 && < 0.4,
     text >= 1 && < 1.3,
-    vector == 0.10.*,
     bytestring >= 0.10 && < 0.11,
+    vector == 0.10.*,
     -- errors:
     loch-th == 0.2.*,
     placeholders == 0.1.*,
@@ -114,6 +114,7 @@ test-suite tests
     scientific >= 0.2 && < 0.4,
     text >= 1 && < 1.3,
     bytestring >= 0.10 && < 0.11,
+    vector == 0.10.*,
     -- general:
     base-prelude >= 0.1.3 && < 0.2
 

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -1,7 +1,7 @@
 name:
   postgresql-binary
 version:
-  0.5.2
+  0.5.3
 synopsis:
   Encoders and decoders for the PostgreSQL's binary format
 description:


### PR DESCRIPTION
This adds a `vector` dependency, hopefully that's not an issue given how ubiquitous it is.

Probably could do with some tests, I've only had a go (with success) at parsing the output of `hasql-postgres` `array_agg(...)` queries (using `hasql-postgres` to separate the elements). The only documentation about these is the source code, so I'm not certain if I'm following the "spec" exactly. I ended up just going through the raw output to figure out the layout, since that was more enlightening and straightforward than deciphering the C code.