### PR TITLE
Support for `inet` data type.

### DIFF
--- a/library/PostgreSQL/Binary/Data.hs
+++ b/library/PostgreSQL/Binary/Data.hs
@@ -56,3 +56,45 @@ type UUID =
 -- 
 type Numeric =
   (Int16, Word16, Vector Int16)
+
+-- |
+-- Representation of the PostgreSQL Network Address Type @inet@.
+--
+-- The Inet type holds an IPv4 or IPv6 host address, and optionally its subnet.
+-- The subnet is represented by the number of network address bits present in the host address (the "netmask").
+-- If the subnet portion is missing, the netmask is 32 for IPv4 and 128 for IPv6.
+data Inet
+  = InetIPv4 IPv4
+  | InetIPv4Subnet IPv4 Netmask
+  | InetIPv6 IPv6
+  | InetIPv6Subnet IPv6 Netmask
+  deriving (Eq, Show)
+
+type IPv4 = (Word8, Word8, Word8, Word8)
+
+type IPv6 = (Word16, Word16, Word16, Word16, Word16, Word16, Word16, Word16)
+
+type Netmask = Word8
+
+maxNetmaskIPv4 :: Word8
+maxNetmaskIPv4 = 32
+
+maxNetmaskIPv6 :: Word8
+maxNetmaskIPv6 = 128
+
+-- | Address family AF_INET
+afInet :: Word8
+afInet = 2
+
+-- | Address family AF_INET6
+afInet6 :: Word8
+afInet6 = 3
+
+ipv4Size :: Int8
+ipv4Size = 4
+
+ipv6Size :: Int8
+ipv6Size = 16
+
+isCidr :: Word8
+isCidr = 0

--- a/library/PostgreSQL/Binary/Decoder.hs
+++ b/library/PostgreSQL/Binary/Decoder.hs
@@ -17,6 +17,7 @@ module PostgreSQL.Binary.Decoder
   fn,
   numeric,
   uuid,
+  inet,
   json_ast,
   json_bytes,
   jsonb_ast,
@@ -151,6 +152,47 @@ numeric =
 uuid :: Decoder UUID
 uuid =
   UUID.fromWords <$> intOfSize 4 <*> intOfSize 4 <*> intOfSize 4 <*> intOfSize 4
+
+{-# INLINABLE ipv4 #-}
+ipv4 :: Decoder Data.IPv4
+ipv4 =
+  (,,,) <$> intOfSize 1 <*> intOfSize 1 <*> intOfSize 1 <*> intOfSize 1
+
+{-# INLINABLE ipv6 #-}
+ipv6 :: Decoder Data.IPv6
+ipv6 =
+  (,,,,,,,) <$> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2 <*> intOfSize 2
+
+{-# INLINABLE inet #-}
+inet :: Decoder Data.Inet
+inet = do
+  af <- intOfSize 1
+  netmask <- intOfSize 1
+  isCidr <- intOfSize 1
+  ipSize <- intOfSize 1
+  if af == Data.afInet
+    then do
+      ip <- ipv4
+      return $ inetIPv4FromBytes af netmask isCidr ipSize ip
+    else do
+      ip <- ipv6
+      return $ inetIPv6FromBytes af netmask isCidr ipSize ip
+
+{-# INLINABLE inetIPv4FromBytes #-}
+inetIPv4FromBytes:: Word8 -> Word8 -> Word8 -> Int8 -> Data.IPv4 -> Data.Inet
+inetIPv4FromBytes _ netmask _ _ ip =
+  if netmask == Data.maxNetmaskIPv4 then
+    Data.InetIPv4 ip
+  else
+    Data.InetIPv4Subnet ip netmask
+
+{-# INLINABLE inetIPv6FromBytes #-}
+inetIPv6FromBytes:: Word8 -> Word8 -> Word8 -> Int8 -> Data.IPv6 -> Data.Inet
+inetIPv6FromBytes _ netmask _ _ ip =
+  if netmask == Data.maxNetmaskIPv6 then
+    Data.InetIPv6 ip
+  else
+    Data.InetIPv6Subnet ip netmask
 
 {-# INLINABLE json_ast #-}
 json_ast :: Decoder Aeson.Value

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -141,6 +141,8 @@ binary =
             ,
             stdRoundtrip "uuid" Gens.uuid PTI.uuid Encoder.uuid Decoder.uuid
             ,
+            stdRoundtrip "inet" Gens.inet PTI.inet Encoder.inet Decoder.inet
+            ,
             stdRoundtrip "int2_int16" Gens.auto PTI.int2 Encoder.int2_int16 Decoder.int
             ,
             stdRoundtrip "int2_word16" Gens.auto PTI.int2 Encoder.int2_word16 Decoder.int

--- a/tasty/Main/Gens.hs
+++ b/tasty/Main/Gens.hs
@@ -120,6 +120,16 @@ uuid :: Gen UUID.UUID
 uuid =
   UUID.fromWords <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
+inet :: Gen Data.Inet
+inet = do
+  ipv6 <- choose (True, False)
+  subnetOn <- choose (True, False)
+  case (ipv6, subnetOn) of
+    (False, False) -> Data.InetIPv4 <$> ((,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
+    (False, True) ->  Data.InetIPv4Subnet <$> ((,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary) <*> choose (0, Data.maxNetmaskIPv4 - 1)
+    (True, False) -> Data.InetIPv6 <$> ((,,,,,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
+    (True, True) -> Data.InetIPv6Subnet <$> ((,,,,,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary) <*> choose (0, Data.maxNetmaskIPv6 - 1)
+
 arrayRep :: Gen (Word32, Data.Array)
 arrayRep =
   do


### PR DESCRIPTION
Implemented Encoder and Decoder for `inet` PostgreSQL data type.

Created `Inet` type in Data.hs which has constructors for IPv4 and IPv6, with or without netmask.

Added roundtrip test for `Inet` in Main.hs of Tasty test.
