### PR TITLE
Allow containers 0.6.x

### DIFF
--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -83,7 +83,7 @@ library
     vector >= 0.10 && < 0.13,
     network-ip >= 0.2 && < 1,
     unordered-containers == 0.2.*,
-    containers == 0.5.*,
+    containers >= 0.5 && < 0.7,
     -- errors:
     loch-th == 0.2.*,
     placeholders == 0.1.*,


### PR DESCRIPTION
Tested via compilation using containers-0.6.0.1

I'd appreciate a Cabal revision as well for https://github.com/commercialhaskell/stackage/pull/4162