### PR TITLE
Fix compatibility with rebase/rerebase 1.4+

### DIFF
--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Main.Prelude hiding (assert, isRight, isLeft)
+import Main.Prelude hiding (assert, isRight, isLeft, select)
 import Control.Monad.IO.Class
 import Test.QuickCheck.Instances
 import Test.Tasty


### PR DESCRIPTION
The new releases of rebase/rerebase provides "select" from the selective package. Simply hiding it fixes compatibility with the new versions.

The error looks like:
```
tasty/Main.hs:38:13: error:
    Ambiguous occurrence ‘select’
    It could refer to either ‘Main.Prelude.select’,
                             imported from ‘Main.Prelude’ at tasty/Main.hs:3:1-52
                             (and originally defined in ‘selective-0.3:Control.Selective’)
                          or ‘Main.select’, defined at tasty/Main.hs:268:1
   |
38 |             select "select (234 :: int8)" (const B.int) (234 :: Int32)
   |             ^^^^^^
```