### PR TITLE
Fix compatibility with rebase 1.7.1.1+

### DIFF
--- a/tasty/Main/DB.hs
+++ b/tasty/Main/DB.hs
@@ -8,7 +8,7 @@ module Main.DB
 )
 where
 
-import Main.Prelude
+import Main.Prelude hiding (unit)
 import Control.Monad.Trans.Reader
 import Control.Monad.IO.Class
 import qualified Database.PostgreSQL.LibPQ as LibPQ


### PR DESCRIPTION
Fixes the following build failure, and all tests pass afterwards:

```
[4 of 9] Compiling Main.DB          ( tasty/Main/DB.hs, dist/build/tasty/tasty-tmp/Main/DB.dyn_o )

tasty/Main/DB.hs:5:3: error:
    Ambiguous occurrence ‘unit’
    It could refer to
       either ‘Main.Prelude.unit’,
              imported from ‘Main.Prelude’ at tasty/Main/DB.hs:11:1-19
              (and originally defined in ‘profunctors-5.5.2:Data.Profunctor.Adjunction’)
           or ‘Main.DB.unit’, defined at tasty/Main/DB.hs:38:1
  |
5 |   unit,
  |   ^^^^
```