### PR TITLE
update bounds of binary-parser

### DIFF
--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -70,7 +70,7 @@ library
     PostgreSQL.Binary.BuilderPrim
   build-depends:
     -- parsing:
-    binary-parser >=0.5 && <0.6,
+    binary-parser >=0.5.6 && <0.6,
     -- building:
     bytestring-strict-builder >=0.4.2 && <0.5,
     -- data:


### PR DESCRIPTION
versions lower than 0.5.6 don't have `MonadFail`