### PR TITLE
Address GHC 9.8 portability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.1.1
+
+- GHC 9.8 portability
+
 # 0.13
 
 - Removed `PostgreSQL.Binary.Data`. Because it was causing Haddock in the dependant packages to unpredictably redirect to it instead of the original location regardless of whether they were imported from it.

--- a/library/PostgreSQL/Binary/Prelude.hs
+++ b/library/PostgreSQL/Binary/Prelude.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module PostgreSQL.Binary.Prelude
   ( module Exports,
     LazyByteString,
@@ -37,7 +38,11 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports
 import Data.Function as Exports hiding (id, (.))
+#if MIN_VERSION_base(4,19,0)
+import Data.Functor as Exports hiding (unzip)
+#else
 import Data.Functor as Exports
+#endif
 import Data.Functor.Identity as Exports
 import Data.HashMap.Strict as Exports (HashMap)
 import Data.IORef as Exports

--- a/postgresql-binary.cabal
+++ b/postgresql-binary.cabal
@@ -1,7 +1,7 @@
 name:
   postgresql-binary
 version:
-  0.13.1
+  0.13.1.1
 synopsis:
   Encoders and decoders for the PostgreSQL's binary format
 description:


### PR DESCRIPTION
- Avoid error due to `unzip` import conflict with new Data.Functor.unzip